### PR TITLE
Fix language disposable spelling and typo

### DIFF
--- a/src/vs/workbench/contrib/void/browser/react/src/markdown/ChatMarkdownRender.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/markdown/ChatMarkdownRender.tsx
@@ -288,7 +288,7 @@ const RenderToken = ({ token, inPTag, codeURI, chatMessageLocation, tokenIdx, ..
 
 		if (!contents) return null
 
-		// figure out langauge and URI
+                // figure out language and URI
 		let uri: URI | null
 		let language: string
 		if (codeURI) {

--- a/src/vs/workbench/services/treeSitter/browser/treeSitterCodeEditors.ts
+++ b/src/vs/workbench/services/treeSitter/browser/treeSitterCodeEditors.ts
@@ -89,9 +89,9 @@ export class TreeSitterCodeEditors extends Disposable {
 				this._textModels.add(model);
 			}
 			if (!this._languageEditors.has(editor)) {
-				const langaugeEditorDisposables = new DisposableStore();
-				langaugeEditorDisposables.add(editor.onDidScrollChange(() => this._onViewportChange(editor), this));
-				this._languageEditors.set(editor, langaugeEditorDisposables);
+                               const languageEditorDisposables = new DisposableStore();
+                               languageEditorDisposables.add(editor.onDidScrollChange(() => this._onViewportChange(editor), this));
+                               this._languageEditors.set(editor, languageEditorDisposables);
 				this._onViewportChange(editor);
 			}
 		}


### PR DESCRIPTION
## Summary
- fix variable name `langaugeEditorDisposables`
- correct typo in comment in `ChatMarkdownRender.tsx`

## Testing
- `npm run monaco-compile-check`
- `npm run test-node`


------
https://chatgpt.com/codex/tasks/task_e_6843e5a03c9883278763219836bf793f