### PR TITLE
Fix duplicate pageerror listener in monaco tests

### DIFF
--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -42,14 +42,10 @@ beforeEach(async function () {
 	});
 
 	pageErrors.length = 0;
-	page.on('pageerror', (e) => {
-		console.log(e);
-		pageErrors.push(e);
-	});
-	page.on('pageerror', (e) => {
-		console.log(e);
-		pageErrors.push(e);
-	});
+       page.on('pageerror', (e) => {
+               console.log(e);
+               pageErrors.push(e);
+       });
 });
 
 afterEach(async () => {


### PR DESCRIPTION
## Summary
- deduplicate `pageerror` handler in monaco test

## Testing
- `npm run compile` *(fails: Cannot find module '/workspace/void/node_modules/typescript/bin/tsc')*
- `npm run test` *(fails: Cannot find module 'yaserver')*

------
https://chatgpt.com/codex/tasks/task_e_6843f957237083278cef87866dcff676